### PR TITLE
Style and theme adjustments

### DIFF
--- a/demo/assets/css/app.css
+++ b/demo/assets/css/app.css
@@ -3,16 +3,10 @@
 @plugin "./tailwind_heroicons.js";
 
 @plugin "daisyui" {
-  themes: dark, cupcake, bumblebee, emerald, corporate, synthwave, retro,
+  themes: light, dark, cupcake, bumblebee, emerald, corporate, synthwave, retro,
     cyberpunk, valentine, halloween, garden, forest, aqua, lofi, pastel, fantasy,
     wireframe, black, luxury, dracula, cmyk, autumn, business, acid, lemonade,
     night, coffee, winter, dim, nord, sunset;
-}
-
-@theme {
-  --radius-badge: var(--rounded-badge, 1.9rem);
-  --radius-box: var(--rounded-box, 1rem);
-  --radius-btn: var(--rounded-btn, 0.5rem);
 }
 
 @plugin "daisyui/theme" {
@@ -25,14 +19,14 @@
   --color-base-200: oklch(96.115% 0 0deg);
   --color-base-300: oklch(92.4169% 0.0011 197.1376deg/100%);
   --color-base-content: oklch(21% 0.006 285.885deg);
-  --color-primary: oklch(53.68% 0.224 259.92deg);
+  --color-primary: oklch(48.82% 0.2172 264.38deg);
   --color-primary-content: oklch(100% 0 0deg);
   --color-secondary: oklch(74.94% 0.182 67.69deg);
   --color-secondary-content: oklch(100% 0 0deg);
   --color-accent: oklch(77% 0.152 181.912deg);
   --color-accent-content: oklch(38% 0.063 188.416deg);
-  --color-neutral: oklch(35.97% 0.031 257.68deg);
-  --color-neutral-content: oklch(100% 0 0deg);
+  --color-neutral: oklch(32.18% 0.0248 255.7deg);
+  --color-neutral-content: oklch(89.5% 0.0116 252.1deg);
   --color-info: oklch(74% 0.16 232.661deg);
   --color-info-content: oklch(29% 0.066 243.157deg);
   --color-success: oklch(76% 0.177 163.223deg);
@@ -43,7 +37,7 @@
   --color-error-content: oklch(27% 0.105 12.094deg);
   --radius-selector: 2rem;
   --radius-field: 0.5rem;
-  --radius-box: 0.5rem;
+  --radius-box: 1rem;
   --size-selector: 0.25rem;
   --size-field: 0.25rem;
   --border: 1px;

--- a/demo/lib/demo_web/components/layouts/root.html.heex
+++ b/demo/lib/demo_web/components/layouts/root.html.heex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="[scrollbar-gutter:stable] h-full" data-theme={assigns[:theme] || "light"}>
+<html lang="en" class="[scrollbar-gutter:stable] h-full" data-theme={assigns[:theme] || "backpex"}>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/lib/backpex/fields/belongs_to.ex
+++ b/lib/backpex/fields/belongs_to.ex
@@ -177,7 +177,7 @@ defmodule Backpex.Fields.BelongsTo do
           prompt={@prompt}
           value={@value && Map.get(@value, :id)}
           input_wrapper_class=""
-          input_class={["select select-sm", if(not @valid, do: "select-error")]}
+          input_class={["select select-ghost", if(not @valid, do: "select-error")]}
           disabled={@readonly}
           hide_errors
         />

--- a/lib/backpex/fields/text.ex
+++ b/lib/backpex/fields/text.ex
@@ -98,7 +98,7 @@ defmodule Backpex.Fields.Text do
           type="text"
           field={@form[:value]}
           placeholder={@field_options[:placeholder]}
-          input_class={["input input-sm", @valid && "[:not(:hover)]:input-ghost", !@valid && "input-error bg-error/10"]}
+          input_class={["input", @valid && "[:not(:hover)]:input-ghost", !@valid && "input-error bg-error/10"]}
           phx-debounce="100"
           readonly={@readonly}
           hide_errors

--- a/lib/backpex/html/core_components.ex
+++ b/lib/backpex/html/core_components.ex
@@ -43,7 +43,7 @@ defmodule Backpex.HTML.CoreComponents do
         type="button"
         phx-click={@clear_event}
         phx-value-field={@filter_name}
-        class="indicator-item bg-base-300 rounded-badge grid place-items-center p-1 shadow-sm transition duration-75 hover:text-secondary hover:scale-110"
+        class="indicator-item bg-base-300 badge badge-outline grid h-5 w-5 place-items-center border-0 p-1 shadow-sm transition duration-75 hover:text-secondary hover:scale-110"
         aria-label={Backpex.translate({"Clear %{name} filter", %{name: @label}})}
       >
         <.icon name="hero-x-mark" class="h-3 w-3" />

--- a/lib/backpex/html/form.ex
+++ b/lib/backpex/html/form.ex
@@ -197,7 +197,9 @@ defmodule Backpex.HTML.Form do
           name={@name}
           id={@id}
           value={Phoenix.HTML.Form.normalize_value(@type, @value)}
-          class={@input_class || ["input w-full input-lg text-base", @input_class, @errors != [] && "input-error bg-error/10"]}
+          class={
+            @input_class || ["input input-lg w-full text-base", @input_class, @errors != [] && "input-error bg-error/10"]
+          }
           {@rest}
         />
       </fieldset>


### PR DESCRIPTION
I adjusted the backpex theme to be even more close to the current one with daisyUI4, set it up as the default theme and also removed the extra round vars and fixed the badge (they break themes that expect themes to be more squared like retro and cyberpunk for example).

I also adjusted the size of the text for the inputs in the tables, there's probably a few more places where `-sm` isn't needed anymore because tailwind changed the scaling with v4 that will need to be fixed.